### PR TITLE
update certFile and keyFile name as small letter

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	certFile       = "ssl/Server.crt"
-	keyFile        = "ssl/Server.pem"
+	certFile       = "ssl/server.crt"
+	keyFile        = "ssl/server.pem"
 	maxHeaderBytes = 1 << 20
 	ctxTimeout     = 5
 )


### PR DESCRIPTION
update certFile and keyFile name as small letter, because when running make build or make run command it give us 
**open ssl/Server.crt: no such file or directory** Error